### PR TITLE
Nicer error logging

### DIFF
--- a/src/migration/transform.ts
+++ b/src/migration/transform.ts
@@ -34,7 +34,7 @@ export const defineTransform = (
 		}
 		const transformResult = transformer(input);
 		if (!transformResult.success) {
-			return failure(`Error applying transform`, versions, transformResult);
+			return failure(`Error applying transform`, versions, ...transformResult.errors);
 		}
 		return success({
 			...transformResult.data,

--- a/src/tasks/migrateAndUpdateStudy.ts
+++ b/src/tasks/migrateAndUpdateStudy.ts
@@ -131,7 +131,7 @@ const migrateAndUpdateStudy =
 				.run();
 
 			if (!pageResult.success) {
-				logger.error(pageResult.errors);
+				logger.error(...pageResult.errors);
 				return summary;
 			}
 
@@ -143,7 +143,7 @@ const migrateAndUpdateStudy =
 				} else {
 					summary.counts.error++;
 					summary.counts.processed++;
-					logger.error(result.errors);
+					logger.error(...result.errors);
 				}
 			});
 


### PR DESCRIPTION
Cleans up logging of errors, takes error message from being an array with a lot of escape characters to just being a list of messages separated by dashes.

Original: ```2022-11-16T17:23:04.582Z error: [SchemaMigrator.Task.migrateAndUpdateStudy] ["Error applying transform","{\"start\":{\"name\":\"consensus_sequence\",\"version\":3},\"end\":{\"name\":\"consensus_sequence\",\"version\":4}}","{\"success\":false,\"errors\":[\"Cannot update `sample_collection.fasta_header_name` since the available value does not match the required regular expression.\",\"ABPL-AB\",\"84553a76-fd1c-4620-953a-76fd1cf62067\",\"AB_73455\"]}"]```

Updated: ```2022-11-16T17:23:04.582Z error: [SchemaMigrator.Task.migrateAndUpdateStudy] Error applying transform - {"start":{"name":"consensus_sequence","version":3},"end":{"name":"consensus_sequence","version":4}}" - Cannot update `sample_collection.fasta_header_name` since the available value does not match the required regular expression. - ABPL-AB - 84553a76-fd1c-4620-953a-76fd1cf62067 - AB_73455```